### PR TITLE
Add plain HTML AdditionalInfo and EditInfo components

### DIFF
--- a/src/components/AdditionalInfo.jsx
+++ b/src/components/AdditionalInfo.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+/**
+ * Presents additional RFQ/PO details in a full-width, equal-height container.
+ * Tailwind classes have been removed in favor of basic HTML structure
+ * so the component can be styled manually or with external stylesheets.
+ */
+export default function AdditionalInfo({ onEdit }) {
+  return (
+    <div style={containerStyle}>
+      <div style={{ flex: 1 }}>
+        <h3 style={titleStyle}>Additional Information</h3>
+        <p style={bodyStyle}>
+          Details about the current request or purchase order appear here.
+        </p>
+      </div>
+      <button type="button" onClick={onEdit} style={buttonStyle}>
+        Edit
+      </button>
+    </div>
+  );
+}
+
+const containerStyle = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  border: '1px solid #d1d5db',
+  borderRadius: '8px',
+  padding: '16px',
+  boxSizing: 'border-box',
+};
+
+const titleStyle = {
+  margin: '0 0 8px',
+  fontSize: '18px',
+  fontWeight: 'bold',
+};
+
+const bodyStyle = {
+  margin: 0,
+};
+
+const buttonStyle = {
+  alignSelf: 'flex-end',
+  padding: '8px 16px',
+  backgroundColor: '#2563eb',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+};
+

--- a/src/components/EditInfo.jsx
+++ b/src/components/EditInfo.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+
+/**
+ * Editing interface for RFQ/PO notes. The layout mirrors the static
+ * AdditionalInfo component but provides controls for modifying content.
+ * Tailwind has been removed in favor of simple HTML structures and inline styles.
+ */
+export default function EditInfo({ initialNotes = '', onSave, onCancel }) {
+  const [notes, setNotes] = useState(initialNotes);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onSave) {
+      onSave(notes);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={containerStyle}>
+      <label htmlFor="notes" style={labelStyle}>Notes</label>
+      <textarea
+        id="notes"
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        style={textareaStyle}
+      />
+      <div style={actionsStyle}>
+        {onCancel && (
+          <button type="button" onClick={onCancel} style={cancelButtonStyle}>
+            Cancel
+          </button>
+        )}
+        <button type="submit" style={saveButtonStyle}>
+          Save
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const containerStyle = {
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  border: '1px solid #d1d5db',
+  borderRadius: '8px',
+  padding: '16px',
+  boxSizing: 'border-box',
+};
+
+const labelStyle = {
+  fontWeight: 'bold',
+  marginBottom: '8px',
+};
+
+const textareaStyle = {
+  flex: 1,
+  resize: 'none',
+  padding: '8px',
+  marginBottom: '16px',
+};
+
+const actionsStyle = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '8px',
+};
+
+const buttonBase = {
+  padding: '8px 16px',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+};
+
+const cancelButtonStyle = {
+  ...buttonBase,
+  backgroundColor: '#e5e7eb',
+};
+
+const saveButtonStyle = {
+  ...buttonBase,
+  backgroundColor: '#16a34a',
+  color: '#fff',
+};
+


### PR DESCRIPTION
## Summary
- Add `AdditionalInfo` component using plain HTML structure with full-width, equal-height container and edit callback.
- Add `EditInfo` component with basic form markup that preserves onSave/onCancel behavior.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b750d3b33883319fc552ab6533aba9